### PR TITLE
Fix broken DOCTYPE element in `_Layout.cshtml`

### DIFF
--- a/DraftSimulator.Web/Views/Shared/_Layout.cshtml
+++ b/DraftSimulator.Web/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿<<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
I realize this repository is simply a demo, but I noticed a hanging "<" on the user interface during your YouTube video and on your hosted demo (https://draftsimulator.azurewebsites.net).